### PR TITLE
add movie model specs and validations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,4 +13,5 @@ AllCops:
     - 'db/migrate/*'
     - 'db/schema.rb'
     - 'config/**/*'
+    - 'spec/rails_helper.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'puma', '~> 5.0'
 # Use Active Storage variant
 # gem 'image_processing', '~> 1.2'
 gem 'devise', '~> 4.8.0'
-gem 'devise_token_auth', '~> 1.1.5'
+gem 'devise_token_auth', '~> 1.2.0'
 gem 'dotenv-rails', '~> 2.7.6'
 gem 'omniauth', '~> 2.0.4'
 gem 'sentry-rails', '~> 4.6.4'
@@ -41,6 +41,7 @@ group :development, :test do
   gem 'rubocop-rails', '~> 2.11.3'
   gem 'rubocop-rspec', '~> 2.4.0'
   gem 'rspec-rails', '~> 5.0.1'
+  gem 'shoulda-matchers', '~> 5.0.0'
   gem 'factory_bot_rails', '~> 6.2.0'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -36,13 +36,13 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
+  gem 'factory_bot_rails', '~> 6.2.0'
+  gem 'rspec-rails', '~> 5.0.1'
   gem 'rubocop', '~> 1.18'
   gem 'rubocop-performance', '~> 1.11.4'
   gem 'rubocop-rails', '~> 2.11.3'
   gem 'rubocop-rspec', '~> 2.4.0'
-  gem 'rspec-rails', '~> 5.0.1'
   gem 'shoulda-matchers', '~> 5.0.0'
-  gem 'factory_bot_rails', '~> 6.2.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise_token_auth (1.1.5)
+    devise_token_auth (1.2.0)
       bcrypt (~> 3.0)
       devise (> 3.5.2, < 5)
       rails (>= 4.2.0, < 6.2)
@@ -236,6 +236,8 @@ GEM
     sentry-ruby-core (4.6.4)
       concurrent-ruby
       faraday
+    shoulda-matchers (5.0.0)
+      activesupport (>= 5.2.0)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -262,7 +264,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   devise (~> 4.8.0)
-  devise_token_auth (~> 1.1.5)
+  devise_token_auth (~> 1.2.0)
   dotenv-rails (~> 2.7.6)
   factory_bot_rails (~> 6.2.0)
   listen (~> 3.3)
@@ -277,6 +279,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.4.0)
   sentry-rails (~> 4.6.4)
   sentry-ruby (~> 4.6.4)
+  shoulda-matchers (~> 5.0.0)
   spring
   tzinfo-data
 

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -2,4 +2,9 @@
 
 class Movie < ApplicationRecord
   has_many :screenings, dependent: :destroy
+  validates :title, presence: true
+  validates :description, presence: true
+  validates :genre, presence: true
+  validates :director, presence: true
+  validates :duration, presence: true, numericality: { greater_than: 10 }
 end

--- a/spec/factories/movie.rb
+++ b/spec/factories/movie.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :movie do
+    sequence(:title) { |n| "Sample movie #{n}" }
+    description { 'Lorem ipsum dolor sit amet' }
+    genre { 'Sample genre' }
+    director { 'Sample director' }
+    duration { 90 }
+  end
+end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -4,17 +4,17 @@ require 'rails_helper'
 
 RSpec.describe Movie, type: :model do
   describe '#validations' do
-    let(:movie) { build(:movie) }
+    subject { build(:movie) }
 
-    it { is_expected.to validate_presence_of(:title) }
-    it { is_expected.to validate_presence_of(:description) }
-    it { is_expected.to validate_presence_of(:genre) }
-    it { is_expected.to validate_presence_of(:director) }
-    it { is_expected.to validate_presence_of(:duration) }
-    it { is_expected.to validate_numericality_of(:duration).is_greater_than(10) }
+    it { should validate_presence_of(:title) }
+    it { should validate_presence_of(:description) }
+    it { should validate_presence_of(:genre) }
+    it { should validate_presence_of(:director) }
+    it { should validate_presence_of(:duration) }
+    it { should validate_numericality_of(:duration).is_greater_than(10) }
   end
 
   describe '#associations' do
-    it { is_expected.to have_many(:screenings) }
+    it { should have_many(:screenings) }
   end
 end

--- a/spec/models/movie_spec.rb
+++ b/spec/models/movie_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Movie, type: :model do
+  describe '#validations' do
+    let(:movie) { build(:movie) }
+
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:description) }
+    it { is_expected.to validate_presence_of(:genre) }
+    it { is_expected.to validate_presence_of(:director) }
+    it { is_expected.to validate_presence_of(:duration) }
+    it { is_expected.to validate_numericality_of(:duration).is_greater_than(10) }
+  end
+
+  describe '#associations' do
+    it { is_expected.to have_many(:screenings) }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,7 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -63,4 +64,11 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  Shoulda::Matchers.configure do |config|
+    config.integrate do |with|
+      with.test_framework :rspec
+      with.library :rails
+    end
+  end
 end


### PR DESCRIPTION
- added movie model specs 
- added movie model validations
- added 'shoulda-matchers' gem
- updated _devise-token-auth_ gem version due to deprecation warning while running _rspec_
(DEPRECATION WARNING: Devise::Models::Authenticatable::BLACKLIST_FOR_SERIALIZATION is deprecated! Use Devise::Models::Authenticatable::UNSAFE_ATTRIBUTES_FOR_SERIALIZATION instead.)